### PR TITLE
set min height for brand header icon

### DIFF
--- a/src/popup/pages/brand/brand.scss
+++ b/src/popup/pages/brand/brand.scss
@@ -14,6 +14,7 @@
     &__icon {
       min-width: 72px;
       max-width: 72px;
+      height: 72px;
       border-radius: 50vh;
       margin-right: 20px;
       user-select: none;


### PR DESCRIPTION
For ex: the Venue brand icon height is smaller than the hover-icon height.